### PR TITLE
Exception when no Title/CreatedDate/UpdatedDate

### DIFF
--- a/Tomboy2Evernote.py
+++ b/Tomboy2Evernote.py
@@ -29,17 +29,28 @@ def process_files(inputdir, outputdir):
 
 def get_title(note_body):
     title_regex = re.compile("<title>(.+?)</title>")
-    return title_regex.search(note_body).group(1)
+    matches = title_regex.search(note_body);
+    if matches:
+        return matches.group(1)
+    else:
+       return "No Tiitle"
 
 
 def get_created_date(note_body):
-    title_regex = re.compile("<create-date>(.+?)</create-date>")
-    return title_regex.search(note_body).group(1)
-
+    created_date_regex = re.compile("<create-date>(.+?)</create-date>")
+    matches = created_date_regex.search(note_body);
+    if matches:
+        return matches.group(1)
+    else:
+       return "No Created Date"
 
 def get_updated_date(note_body):
-    title_regex = re.compile("<last-change-date>(.+?)</last-change-date>")
-    return title_regex.search(note_body).group(1)
+    updated_date_regex = re.compile("<last-change-date>(.+?)</last-change-date>")
+    matches = updated_date_regex.search(note_body);
+    if matches:
+        return matches.group(1)
+    else:
+       return "No Updated Date"
 
 
 def tomboy_to_enex_date(tomboy_date):


### PR DESCRIPTION
Some Tomboy Notes are created without title or dates, we need to capture these exceptions.
After the updated script, I successfully exported my 734 Tomboy Notes and then imported into my Evernote.
Thanks, Buddy.
